### PR TITLE
Fix homepage and theme

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,0 +1,1 @@
+README.md

--- a/src/posts/posts.json
+++ b/src/posts/posts.json
@@ -1,0 +1,3 @@
+{
+  "layout": "layout.njk"
+}


### PR DESCRIPTION
## Summary
- prevent README instructions from rendering on homepage by adding `.eleventyignore`
- give posts the dark theme layout by default

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865547ece708331af31a635cfc1f5e4